### PR TITLE
Added 'Show For Current File' feature.

### DIFF
--- a/lib/git-log-view.js
+++ b/lib/git-log-view.js
@@ -14,11 +14,13 @@ var safe_tags = function(str) {
     return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') ;
 };
 
-GitLogView.prototype.initialize = function(repo_name) {
+GitLogView.prototype.initialize = function(repo_name, path) {
     var settings = atom.config.getSettings();
-
+    
     this.info_panel.hide();
-    this.path = repo_name;
+    this.repo_name = repo_name;
+    this.path = (typeof path === 'string' && path.charAt(0) === '/') ?
+        path.substring(1) : null;
     this.font_size = settings.editor.fontSize * settings['git-log'].fontScale;
     this.line_height = Math.round(this.font_size * settings.editor.lineHeight);
     this.get_log();
@@ -47,6 +49,9 @@ GitLogView.prototype.get_log = function() {
     }(this);
 
     var args = ['log', '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw'];
+    if(typeof this.path === 'string') {
+      args.push(this.path);
+    }
     var options = {};
     options.cwd = atom.project.getRepo().getWorkingDirectory();
     return new BufferedProcess({
@@ -193,11 +198,11 @@ GitLogView.prototype.fill_content = function() {
 }
 
 GitLogView.prototype.getTitle = function() {
-    return "Git-log: " + this.path;
+    return "Git-log: " + (this.path ? this.path : this.repo_name);
 };
 
 GitLogView.prototype.getUri = function() {
-    return "git-log://" + this.path;
+    return "git-log://" + this.repo_name + (this.path ? "/" + this.path : "");
 };
 
 GitLogView.prototype.get_image = function(email) {

--- a/lib/git-log.js
+++ b/lib/git-log.js
@@ -18,6 +18,19 @@ module.exports = {
                 atom.workspace.open(uri);
             }
         })
+        
+        atom.workspaceView.command("git-log:show-for-current-file", function(event) {
+            var repo = check_repo_validity();
+            var file = check_current_file();
+            if(repo !== null && file !== null) {
+                var uri = "git-log://" + repo + '/' + file;
+                var old_pane = atom.workspace.paneForUri(uri);
+                if (old_pane) {
+                    old_pane.destroyItem(old_pane.itemForUri(uri));
+                }
+                atom.workspace.open(uri);
+            }
+        });
 
         return atom.workspace.registerOpener(function(uri) {
             var error, host, pathname, protocol, ref;
@@ -36,7 +49,7 @@ module.exports = {
                 return;
             }
             var GitLogView = require('./git-log-view');
-            return new GitLogView(host);
+            return new GitLogView(host, pathname);
         });
     }
 };
@@ -51,3 +64,19 @@ var check_repo_validity = function() {
         return null;
     }
 }
+
+var check_current_file = function() {
+    var repo = atom.project.getRepo();
+    var editor = atom.workspace.getActiveTextEditor();
+    var filePath = (editor && editor.getPath()) ?
+        repo.relativize(editor.getPath()) : null;
+    
+    if(filePath &&
+      !repo.isPathIgnored(filePath) &&
+      !/^(\/|\.\.)/.test(filePath)) {
+      return filePath;
+    }
+    else {
+      return null;
+    }
+};


### PR DESCRIPTION
This adds a second command that runs `git log` only on the file open in the current editor tab.

![git-log-screencap](https://cloud.githubusercontent.com/assets/4974151/4345857/8700032a-40e3-11e4-82f6-3d65e7209d34.gif)
