### PR TITLE
Depend on jsdom patched d3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "d3": ">0.0"
+    "d3": "matiasgarciaisaia/d3#jsdom-dependency-patch"
   }
 }


### PR DESCRIPTION
See mbostock/d3#2023
Temporally fixes #9 (at least until d3 next version is published).
