### PR TITLE
Addressed font rendering issue

### DIFF
--- a/lib/git-log-view.js
+++ b/lib/git-log-view.js
@@ -15,12 +15,14 @@ var safe_tags = function(str) {
 };
 
 GitLogView.prototype.initialize = function(repo_name) {
-    var settings = atom.config.getSettings();
+    var editorFontSize = atom.config.get('editor.fontSize');
+    var editorLineHeight = atom.config.get('editor.lineHeight');
+    var fontScale = atom.config.get('git-log.fontScale');
 
     this.info_panel.hide();
     this.path = repo_name;
-    this.font_size = settings.editor.fontSize * settings['git-log'].fontScale;
-    this.line_height = Math.round(this.font_size * settings.editor.lineHeight);
+    this.font_size = editorFontSize * fontScale;
+    this.line_height = Math.round(this.font_size * editorLineHeight);
     this.get_log();
 
     this.resize_started = __bind(this.resize_started, this);
@@ -132,7 +134,7 @@ GitLogView.prototype.fill_content = function() {
             self.previous_line = line_no + 1;
             self.main_panel.find('p:nth-child(' + self.previous_line + ')')
                     .css('background-color', 'rgba(13,128,215,0.65)');
-            
+
             self.info_panel.add_content("Commit:", commit_data.sha1 + " [" + commit_data.sha1.slice(0,7) +"]" );
             self.info_panel.add_content("Parents:", commit_data.parents.map(function(str) {
                     return str.slice(0,10);
@@ -141,7 +143,7 @@ GitLogView.prototype.fill_content = function() {
             self.info_panel.add_content("Author:", commit_data.author_name + ' <' + commit_data.author_email + '>');
             var date = commit_data.author_date.split(/ /);
             self.info_panel.add_content("Date:", date[2] + ' ' + date[1] + ' ' + date[4] + ' ' + date[3].slice(0,8))
-            
+
             // add committer related information
             if(commit_data.committer_name != commit_data.author_name) {
                 self.info_panel.add_content("Committer:", commit_data.committer_name + ' <' + commit_data.committer_email + '>');
@@ -178,13 +180,13 @@ GitLogView.prototype.fill_content = function() {
                 else
                     status_text = 'modified';
                 self.info_panel.status.add_content(status_text);
-                
+
                 index = temp[2].lastIndexOf('/');
                 self.info_panel.name.add_content(temp[2].slice(index + 1));
                 self.info_panel.path.add_content(
                     (index >= 0) ? temp[2].slice(0, index) : ''
                 );
-                
+
                 self.info_panel.addition.add_content(temp[0]);
                 self.info_panel.deletion.add_content(temp[1]);
             }


### PR DESCRIPTION
Configuration API now recommends using `atom.config.get(key)` to read
config settings. See https://atom.io/docs/v0.177.0/advanced/configuration

The former `getSettings()` call in `lib/git-log-view.js:18` returned default
settings (no user overrides).

Fixes #42 