### PR TITLE
:fire: Remove `onDidChange` callbacks

### DIFF
--- a/lib/git-log-view.js
+++ b/lib/git-log-view.js
@@ -180,14 +180,6 @@ GitLogView.prototype.getURI = function() {
     return "git-log://" + this.path;
 };
 
-GitLogView.prototype.onDidChangeTitle = function() {
-    return;
-};
-
-GitLogView.prototype.onDidChangeModified = function() {
-    return;
-};
-
 GitLogView.prototype.get_image = function(email) {
     var crypto = require('crypto');
     var base = "http://www.gravatar.com/avatar/";


### PR DESCRIPTION
They were not returning a valid `Disposable` object and, since they were not used internally, we can delete them so that https://github.com/atom/tabs/issues/183 is not a problem anymore.

For some reason I am not able to run this package by cloning it and running `apm link`. Any ideas of what’s going on there?

Nice job with this package, by the way! :sparkles: