### PR TITLE
Configurable Avatar URL for Libravatar-Compatible Services

### DIFF
--- a/lib/git-log-view.js
+++ b/lib/git-log-view.js
@@ -175,7 +175,7 @@ GitLogView.prototype.getUri = function() {
 
 GitLogView.prototype.get_image = function(email) {
     var crypto = require('crypto');
-    var base = "http://www.gravatar.com/avatar/";
+    var base = atom.config.get('git-log.avatarUrl');
     return base + crypto.createHash('md5').update(email.toLowerCase().trim()).digest('hex') + "?s=64";
 };
 

--- a/lib/git-log.js
+++ b/lib/git-log.js
@@ -12,7 +12,11 @@ module.exports = {
       fontFamily: {
         type: 'string',
         default: "Inconsolata, Monaco, Consolas, 'Courier New', Courier"
-      }
+        },
+      avatarUrl: {
+        type: 'string',
+        default: "http://www.gravatar.com/avatar/"
+        }
     },
     activate: function() {
         atom.commands.add("atom-workspace", "git-log:show", function(event) {


### PR DESCRIPTION
The URL for viewing Avatar-Images is hardcoded to gravatar.com. This should be configurable to enable [Libravatar](https://wiki.libravatar.org/api/)-compatible URLs.

This is my first time working with Atom Packages, so please be gentle :-)