### PR TITLE
Use --no-color when calling `git log`

### DIFF
--- a/lib/git-log-view.js
+++ b/lib/git-log-view.js
@@ -51,7 +51,7 @@ GitLogView.prototype.get_log = function() {
         }
     }(this);
 
-    var args = ['log', '--decorate=full', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw'];
+    var args = ['log', '--decorate=full', '--no-color', '--date=default', '--pretty=fuller', '--all', '--parents', '--numstat', '--topo-order', '--raw'];
     var options = {};
     options.cwd = this.repo.getWorkingDirectory();
 


### PR DESCRIPTION
Fixes issue #33